### PR TITLE
Added tags and removed database so as to revert to environment default

### DIFF
--- a/definitions/evaluation-clickstream.sqlx
+++ b/definitions/evaluation-clickstream.sqlx
@@ -1,7 +1,8 @@
 config {
     type: "operations",
     schema: "search_api",
-    name: "clickstream"
+    name: "clickstream",
+    tags: ["search-monthly"]
 }
 
 MERGE INTO `${dataform.projectConfig.vars.project_id}.automated_evaluation_input.clickstream` T

--- a/definitions/search-intraday.sqlx
+++ b/definitions/search-intraday.sqlx
@@ -1,6 +1,5 @@
 config {
     type: "operations",
-    database: "search-v2-api-staging",
     schema: "search_api",
     name: "search-intraday",
     tags: ["search-intraday"]

--- a/definitions/search.sqlx
+++ b/definitions/search.sqlx
@@ -1,9 +1,8 @@
 config {
     type: "operations",
-    database: "search-v2-api-staging",
     schema: "search_api",
     name: "search",
-    tags: ["search"]
+    tags: ["search-daily"]
 }
 
 MERGE INTO

--- a/definitions/view-item-external-link-intraday.sqlx
+++ b/definitions/view-item-external-link-intraday.sqlx
@@ -1,9 +1,8 @@
 config {
     type: "operations",
-    database: "search-v2-api-staging",
     schema: "search_api",
     name: "view-item-external-link-intraday",
-    tags: ["view-item-external-link-intraday"]
+    tags: ["search-intraday"]
 }
 
 js {

--- a/definitions/view-item-external-link.sqlx
+++ b/definitions/view-item-external-link.sqlx
@@ -1,9 +1,8 @@
 config {
     type: "operations",
-    database: "search-v2-api-staging",
     schema: "search_api",
     name: "view-item-external-link",
-    tags: ["view-item-external-link"]
+    tags: ["search-daily"]
 }
 
 MERGE INTO

--- a/definitions/view-item-intraday.sqlx
+++ b/definitions/view-item-intraday.sqlx
@@ -2,7 +2,7 @@ config {
     type: "operations",
     schema: "search_api",
     name: "view-item-intraday",
-    tags: ["view-item-intraday"]
+    tags: ["search-intraday"]
 }
 
 MERGE INTO

--- a/definitions/view-item.sqlx
+++ b/definitions/view-item.sqlx
@@ -1,9 +1,8 @@
 config {
     type: "operations",
-    database: "search-v2-staging",
     schema: "search_api",
     name: "view_items",
-    tags: ["view_items"]
+    tags: ["search-daily"]
 }
 
 MERGE INTO


### PR DESCRIPTION
* Added tags for `search-intraday`, `search-daily` and `search-monthly`
* Removed `database` from definition config to revert to environment default database (the sink project is still defined in the query but this ensures the actions are suitably named