### PR TITLE
fix: omit searches via query param includelist

### DIFF
--- a/definitions/evaluation-binary.sqlx
+++ b/definitions/evaluation-binary.sqlx
@@ -13,6 +13,30 @@ BEGIN TRANSACTION;
 SET
   PARTITIONTIME = TIMESTAMP_TRUNC((CURRENT_TIMESTAMP()),MONTH);
 
+-- Unpack URL parameters into an ARRAY<STRUCT<key STRING, value STRING>>
+--
+-- Test case:
+-- SELECT UNPACK_PARAMS("https://www.gov.uk/search/all?key_and_value=foo&key_only") AS params
+--
+-- Output in JSON format should be:
+-- [{
+--   "params": [{
+--     "key": "key_and_value",
+--     "value": "foo"
+--   }, {
+--     "key": "key_only",
+--     "value": null
+--   }]
+-- }]
+CREATE TEMP FUNCTION UNPACK_PARAMS(url STRING) AS ((
+  SELECT ARRAY_AGG(
+    STRUCT(
+      SPLIT(keyval, "=")[SAFE_ORDINAL(1)] AS key,
+      SPLIT(keyval, "=")[SAFE_ORDINAL(2)] AS value
+      )
+  ) FROM UNNEST(REGEXP_EXTRACT_ALL(url, "[?&]([^&]+)")) AS keyval
+));
+
 DELETE
 FROM
   automated_evaluation_input.binary
@@ -37,8 +61,16 @@ WITH
       event_name = 'select_item' AND
       item_list_name = 'Search' AND
       search_term IS NOT NULL AND
-      regexp_extract(page_location, "order=([a-zA-Z\\\\-]+)" ) IS NULL AND
-      ARRAY_TO_STRING(regexp_extract_all(page_location, "((?:level_one_taxon|level_two_taxon|content_purpose_supergroup%5B%5D|public_timestamp%5Bfrom%5D|public_timestamp%5Bto%5D)=(?:%20&%20|[^&])*)" ), "&") = '' AND
+      NOT EXISTS (
+        SELECT *
+        FROM UNNEST(UNPACK_PARAMS(page_location))
+        WHERE
+          NOT (key IN ("keywords", "q", "parent", "fbclid")) AND -- allow these particular parameters
+          NOT value IS NULL AND                                  -- allow parameters that have no value
+          NOT (key = "order" AND value = "relevance") AND        -- allow the default order even when it has been explicitly requested
+          NOT (key = "page" AND SAFE_CAST(value AS INT64) <= 10) -- allow clicks from the first 10 pages of search results
+      ) AND
+      search_term NOT LIKE "%[%]%" AND -- exclude queries that have been redacted, because they aren't literal queries
       event_date BETWEEN DATE_TRUNC(DATE_SUB(CURRENT_DATE(),INTERVAL 3 MONTH),MONTH) AND DATE_TRUNC(CURRENT_DATE(),MONTH)
   ),
   grouped AS (

--- a/definitions/evaluation-clickstream.sqlx
+++ b/definitions/evaluation-clickstream.sqlx
@@ -13,6 +13,30 @@ BEGIN TRANSACTION;
 SET
   PARTITIONTIME = TIMESTAMP_TRUNC((CURRENT_TIMESTAMP()),MONTH);
 
+-- Unpack URL parameters into an ARRAY<STRUCT<key STRING, value STRING>>
+--
+-- Test case:
+-- SELECT UNPACK_PARAMS("https://www.gov.uk/search/all?key_and_value=foo&key_only") AS params
+--
+-- Output in JSON format should be:
+-- [{
+--   "params": [{
+--     "key": "key_and_value",
+--     "value": "foo"
+--   }, {
+--     "key": "key_only",
+--     "value": null
+--   }]
+-- }]
+CREATE TEMP FUNCTION UNPACK_PARAMS(url STRING) AS ((
+  SELECT ARRAY_AGG(
+    STRUCT(
+      SPLIT(keyval, "=")[SAFE_ORDINAL(1)] AS key,
+      SPLIT(keyval, "=")[SAFE_ORDINAL(2)] AS value
+      )
+  ) FROM UNNEST(REGEXP_EXTRACT_ALL(url, "[?&]([^&]+)")) AS keyval
+));
+
 DELETE
 FROM
   automated_evaluation_input.clickstream
@@ -37,8 +61,16 @@ INSERT INTO automated_evaluation_input.clickstream (_PARTITIONTIME,
       event_name = 'select_item' AND
       item_list_name = 'Search' AND
       search_term IS NOT NULL AND
-      regexp_extract(page_location, "order=([a-zA-Z\\\\-]+)" ) IS NULL AND
-      ARRAY_TO_STRING(regexp_extract_all(page_location, "((?:level_one_taxon|level_two_taxon|content_purpose_supergroup%5B%5D|public_timestamp%5Bfrom%5D|public_timestamp%5Bto%5D)=(?:%20&%20|[^&])*)" ), "&") = '' AND
+      NOT EXISTS (
+        SELECT *
+        FROM UNNEST(UNPACK_PARAMS(page_location))
+        WHERE
+          NOT (key IN ("keywords", "q", "parent", "fbclid")) AND -- allow these particular parameters
+          NOT value IS NULL AND                                  -- allow parameters that have no value
+          NOT (key = "order" AND value = "relevance") AND        -- allow the default order even when it has been explicitly requested
+          NOT (key = "page" AND SAFE_CAST(value AS INT64) <= 10) -- allow clicks from the first 10 pages of search results
+      ) AND
+      search_term NOT LIKE "%[%]%" AND -- exclude queries that have been redacted, because they aren't literal queries
       event_date BETWEEN DATE_TRUNC(DATE_SUB(CURRENT_DATE(),INTERVAL 3 MONTH),MONTH) AND DATE_TRUNC(CURRENT_DATE(),MONTH)
   ),
   grouped AS (


### PR DESCRIPTION
We need to evaluate the performance of a 'vanilla' search: the first page of results, in a default order, of a keyword-only search. We need the sample query sets of this evaluation to omit searches that use any other filters, sort orders, or that request a second or subsequent page of results.

This is currently achieved by filtering out searches that involve certain query parameters (an excludelist). The excludelist would need to be updated whenever a new query parameter is defined.

The current excludelists don't include the query parameter `manual`, which means that searches that use that query parameter are incorrectly included in the evaluation sample query sets.

This commit replaces the excludelist with an includelist of query parameters that can be used in a 'vanilla' search. The includelist will only need to be updated when such parameters change, which will probably be less often than when the parameters of other kinds of searches change.
