### PR TITLE
[SCH-2050] Update naming from Vertex to Agent Search

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 This repo contains:
 
-- [`definitions/`](definitions/): Google Dataform SQLX pipeline definitions for processing and transforming GA4 data into Google Verex AI Search datasets
+- [`definitions/`](definitions/): Google Dataform SQLX pipeline definitions for processing and transforming GA4 data into Google Cloud Agent Search datasets
 - [`workflow_setting.yaml`](workflow_settings.yaml): Google Dataform workflow settings that apply to all pipelines
 
 ### What's not in this repo


### PR DESCRIPTION
Google have rebranded Vertex AI Search to Agent Search, so we need to update the marketing name in the docs.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2050