### PR TITLE
Add code scanning

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -1,0 +1,12 @@
+name: Lint GitHub Actions
+on:
+  push:
+    paths: ['.github/**']
+jobs:
+  actionlint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          show-progress: false
+      - uses: alphagov/govuk-infrastructure/.github/actions/actionlint@main

--- a/.github/workflows/code-scan.yml
+++ b/.github/workflows/code-scan.yml
@@ -1,0 +1,26 @@
+name: 'Code scan'
+
+on:
+  push:
+    branches:
+      - main
+    paths-ignore:
+      - ".git**"
+  pull_request:
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: 'The branch, tag or SHA to checkout'
+        default: main
+        type: string
+
+jobs:
+  codeql-sast:
+    name: CodeQL SAST scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/codeql-analysis.yml@main
+    permissions:
+      security-events: write
+
+  dependency-review:
+    name: Dependency Review scan
+    uses: alphagov/govuk-infrastructure/.github/workflows/dependency-review.yml@main


### PR DESCRIPTION
Adds dependency review and codeql code scanning workflow. This is mainly to remove [an error](https://github.com/alphagov/seal/blob/main/lib/security_alert_handler.rb#L45) we get when Seal tries to fetch security alerts for the Search team's repos. As search-api-v2-dataform has been added to https://github.com/alphagov/seal/blob/main/ignored_ci_repos.yml, ideally it would be exempt from the code scanning checks, but this is not the case at the moment.

The new workflow currently provides no utility, since there are no dependencies in the repo and CodeQL doesn't support SQL.

We also add a workflow to lint github actions, which is required by govuk guidelines when there are other github actions used within a repo.

Jira ticket: https://gov-uk.atlassian.net/browse/SCH-2157